### PR TITLE
Improve README.md and JS linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "browser": true,
+    "es6": true
+  },
+  "extends": ["eslint:recommended", "google"],
+  "rules": {
+    "no-multi-spaces": "off"
+  }
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,16 +9,19 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Maven compile
-      run: mvn compile
-    - name: npm install dependencies
+      run: mvn package
+    - name: install node dependencies
       if: always()
-      run: npm install clang-format prettier css-validator html-validate
+      run: make node_modules
     - name: Validate HTML
       if: always()
       run: node_modules/html-validate/bin/html-validate.js src/main/webapp/*.html
     - name: Validate CSS
       if: always()
       run: node_modules/css-validator/bin/css-validator src/main/webapp/*.css
+    - name: Validate JavaScript
+      if: always()
+      run: node_modules/eslint/bin/eslint.js src/main/webapp/*.js
     - name: Check HTML Formatting
       if: always()
       run: node_modules/prettier/bin-prettier.js -c src/main/webapp/*.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
+# Ignore generated NPM files
+# These are sometimes included but not necessary for this project
+package-lock.json
+node_modules/
+
+# Ignore generated Maven build files
 target/
+
+# Ignore editor config
 .idea

--- a/README.md
+++ b/README.md
@@ -1,37 +1,34 @@
 # travelbud
 
-## Setup
-In Cloud Shell, run:
-`edit .customize_environment`
+travelbud is a web application for travelers.
 
-Ensure that it has the following lines:
+## Prerequisites
+
+### Cloud Shell
+
+We use [Cloud Shell](https://ssh.cloud.google.com/cloudshell/editor) for
+development, which requires a Google account. Click
+[this link](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fgferioli0418%2Ftravelbud&cloudshell_git_branch=master)
+to directly open this project in Cloud Shell.
+
+### Google Cloud Project
+
+This application is packaged and deployed via App Engine, which requires a
+Google Cloud Project. You might need to change the `<projectId>` value in
+[`pom.xml`](pom.xml) if you're not a collaborator.
+
+## Development
+You can preview the cloned project by packaging and running the app locally:
 ```shell
-npm install -g css-validator
-npm install -g clang-format
-npm install -g html-validate
-npm install -g prettier
+mvn package appengine:run
 ```
 
-## Local development
-Run:
-```shell
-mvn appengine:run
-```
+### Action Cheatsheet
 
-## Deploying
-Run:
-```shell
-mvn appengine:deploy
-```
-
-## HTML/CSS Validation
-Run:
-```shell
-make validate
-```
-
-## Format Code
-Run:
-```shell
-make pretty
-```
+| Action               | Command                | Notes                                      |
+| -------------------- | ---------------------- | ------------------------------------------ |
+| Package the app      | `mvn package`          |                                            |
+| Run the app locally  | `mvn appengine:run`    | You might need to run `mvn package` first. |
+| Deploy the app       | `mvn appengine:deploy` | You might need to run `mvn package` first. |
+| Validate HTML/CSS/JS | `make validate`        |                                            |
+| Format code          | `make pretty`          |                                            |

--- a/makefile
+++ b/makefile
@@ -1,13 +1,22 @@
-CLANG_FORMAT=clang-format --style=Google
+CLANG_FORMAT=node_modules/clang-format/bin/linux_x64/clang-format --style=Google
+CSS_VALIDATOR=node_modules/css-validator/bin/css-validator
+ESLINT=node_modules/eslint/bin/eslint.js
+HTML_VALIDATE=node_modules/html-validate/bin/html-validate.js
+PRETTIER=node_modules/prettier/bin-prettier.js
 
-pretty:
-	prettier --write src/main/webapp/*.{html,css}
+node_modules:
+	npm install clang-format prettier css-validator html-validate eslint eslint-config-google
+
+pretty: node_modules
+	$(PRETTIER) --write src/main/webapp/*.{html,css}
+	$(ESLINT) --fix src/main/webapp/*.js
 	find src/main/java -iname *.java | xargs $(CLANG_FORMAT) -i
 	find src/main/webapp -iname *.js | xargs $(CLANG_FORMAT) -i
 
-validate:
-	html-validate src/main/webapp/*.html
-	css-validator src/main/webapp/*.css
+validate: node_modules
+	$(HTML_VALIDATE) src/main/webapp/*.html
+	$(CSS_VALIDATOR) src/main/webapp/*.css
+	$(ESLINT) src/main/webapp/*.js
 
-build:
-	mvn compile
+package:
+	mvn package

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <artifactId>appengine-maven-plugin</artifactId>
         <version>2.2.0</version>
         <configuration>
-          <projectId>sixtor-sps-spring20</projectId>
+          <projectId>sps-travelbud</projectId>
           <version>1</version>
         </configuration>
       </plugin>

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -1,7 +1,7 @@
 /**
  * Adds a random location to the page.
  */
-function addRandomLocation() {
+function addRandomLocation() {  // eslint-disable-line no-unused-vars
   const locations = ['Canada', 'Mexico', 'US'];
 
   // Pick a random location.


### PR DESCRIPTION
The original README.md assumed you had run `mvn package` and was a little confusing to read. Take a look at the improved [README.md](https://github.com/gferioli0418/travelbud/blob/josue/README.md).

In this PR I've also:
- Added Validation/Linting for JavaScript as well as its check in the workflow
- Removed dependencies off global `npm` installations
- Updated the project ID to be `sps-travelbud` as that's what we'll be using

Fixes #1 