### PR TITLE
Let linter understand async functions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,10 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 2017
+  },
   "env": {
     "browser": true,
-    "es6": true,
-    "ecmaVersion": 2017
+    "es6": true
   },
   "extends": ["eslint:recommended", "google"],
   "rules": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "env": {
     "browser": true,
-    "es6": true
+    "es6": true,
+    "ecmaVersion": 2017,
   },
   "extends": ["eslint:recommended", "google"],
   "rules": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "env": {
     "browser": true,
     "es6": true,
-    "ecmaVersion": 2017,
+    "ecmaVersion": 2017
   },
   "extends": ["eslint:recommended", "google"],
   "rules": {


### PR DESCRIPTION
It looks like [async function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) is something that was only introduced in ECMA 2017. Adding this parser option to the linter will allow it to not detect it as an error